### PR TITLE
feat: Add support for index in query

### DIFF
--- a/src/nodes/indexNode.ts
+++ b/src/nodes/indexNode.ts
@@ -1,0 +1,5 @@
+export type IndexNode = {
+  readonly kind: "IndexNode";
+  readonly index: string;
+};
+  

--- a/src/nodes/queryNode.ts
+++ b/src/nodes/queryNode.ts
@@ -1,6 +1,7 @@
 import { AttributesNode } from "./attributesNode";
 import { ConsistentReadNode } from "./consistentReadNode";
 import { ExpressionNode } from "./expressionNode";
+import { IndexNode } from "./indexNode";
 import { KeyConditionNode } from "./keyConditionNode";
 import { LimitNode } from "./limitNode";
 import { ScanIndexForwardNode } from "./scanIndexForwardNode";
@@ -14,5 +15,6 @@ export type QueryNode = {
   readonly consistentRead?: ConsistentReadNode;
   readonly scanIndexForward?: ScanIndexForwardNode;
   readonly limit?: LimitNode;
+  readonly index?: IndexNode;
   readonly attributes?: AttributesNode;
 };

--- a/src/queryBuilders/queryQueryBuilder.ts
+++ b/src/queryBuilders/queryQueryBuilder.ts
@@ -114,6 +114,8 @@ export interface QueryQueryBuilderInterface<DDB, Table extends keyof DDB, O> {
 
   limit(value: number): QueryQueryBuilderInterface<DDB, Table, O>;
 
+  index(index: string): QueryQueryBuilderInterface<DDB, Table, O>;
+
   scanIndexForward(enabled: boolean): QueryQueryBuilderInterface<DDB, Table, O>;
 
   consistentRead(enabled: boolean): QueryQueryBuilderInterface<DDB, Table, O>;
@@ -260,6 +262,19 @@ export class QueryQueryBuilder<
         limit: {
           kind: "LimitNode",
           limit: value,
+        },
+      },
+    });
+  }
+
+  index(index: string): QueryQueryBuilderInterface<DDB, Table, O> {
+    return new QueryQueryBuilder<DDB, Table, O>({
+      ...this.#props,
+      node: {
+        ...this.#props.node,
+        index: {
+          kind: "IndexNode",
+          index,
         },
       },
     });

--- a/src/queryCompiler/queryCompiler.ts
+++ b/src/queryCompiler/queryCompiler.ts
@@ -104,6 +104,7 @@ export class QueryCompiler {
       filterExpression: filterExpressionNode,
       keyConditions: keyConditionsNode,
       limit: limitNode,
+      index: indexNode,
       scanIndexForward: scanIndexForwardNode,
       consistentRead: consistentReadNode,
       attributes: attributesNode,
@@ -135,6 +136,7 @@ export class QueryCompiler {
         ? compiledFilterExpression
         : undefined,
       Limit: limitNode?.limit,
+      IndexName: indexNode?.index,
       ExpressionAttributeValues: {
         ...Object.fromEntries(keyConditionAttributeValues),
         ...Object.fromEntries(filterExpressionAttributeValues),


### PR DESCRIPTION
Add support for specifying index in QueryQueryBuilder

Mostly copy-pastaed the code for `limit`
