### PR TITLE
Simplify output types

### DIFF
--- a/src/queryBuilders/getItemQueryBuilder.integration.test.ts
+++ b/src/queryBuilders/getItemQueryBuilder.integration.test.ts
@@ -33,12 +33,21 @@ describe("GetItemQueryBuilder", () => {
         dataTimestamp: TEST_DATA[0].dataTimestamp,
       })
       .consistentRead(true)
-      .attributes(["somethingElse", "someBoolean"])
+      .attributes(["userId", "somethingElse", "someBoolean"])
       .execute();
+
+    expectTypeOf(data).toEqualTypeOf<
+      | {
+          userId: string;
+          somethingElse?: number;
+          someBoolean?: boolean;
+        }
+      | undefined
+    >();
 
     expect(data?.somethingElse).toBe(TEST_DATA[0].somethingElse);
     expect(data?.someBoolean).toBe(TEST_DATA[0].someBoolean);
-    expect(Object.keys(data!).length).toBe(2);
+    expect(Object.keys(data!).length).toBe(3);
   });
 
   it("handles selecting nested attributes", async () => {

--- a/src/typeHelpers.test-d.ts
+++ b/src/typeHelpers.test-d.ts
@@ -1,6 +1,35 @@
-import { SelectAttributes, type ObjectFullPaths } from "./typeHelpers";
+import { PartitionKey, SortKey } from ".";
+import {
+  OmitKeys,
+  PickPk,
+  PickSk,
+  PickSkRequired,
+  SelectAttributes,
+  StripKeys,
+  type ObjectFullPaths,
+} from "./typeHelpers";
 
 describe("typeHelpers typecheck", () => {
+  it("PK and SK util", () => {
+    interface Table {
+      pk: PartitionKey<string>;
+      sk: SortKey<number>;
+      somethingElse: string;
+    }
+
+    type pk = PickPk<Table>;
+    expectTypeOf<pk>().toEqualTypeOf<{ pk: string }>();
+
+    type sk = PickSk<Table>;
+    expectTypeOf<sk>().toEqualTypeOf<{ sk?: number }>();
+
+    type skr = PickSkRequired<Table>;
+    expectTypeOf<skr>().toEqualTypeOf<{ sk: number }>();
+
+    type noKeys = OmitKeys<Table>;
+    expectTypeOf<noKeys>().toEqualTypeOf<{ somethingElse: string }>();
+  });
+
   it("ObjectFullPaths typecheck", () => {
     type empty = ObjectFullPaths<{}>;
     expectTypeOf<empty>().toEqualTypeOf<never>();


### PR DESCRIPTION
Instead of getting typehints for garbage like 
<img width="383" alt="image" src="https://github.com/woltsu/tsynamo/assets/97961292/4deec714-cdf9-4b97-8f0f-9ddebb335492">

You get something cleaner like:
<img width="286" alt="image" src="https://github.com/woltsu/tsynamo/assets/97961292/715908ff-49db-48bd-a9d7-636cf34d4c0e">
