### PR TITLE
Add type and module resolution check for prs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Check type and module resolution
+        run: npx @arethetypeswrong/cli --pack


### PR DESCRIPTION
This PR adds a type and module resolution for prs. It runs [arethetypeswrong](https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/main) -tool in CI, which reports if your types or module resolution fails when using esm or csj. Useful in case you change something in your build setup in the future 👍 